### PR TITLE
fix: Add Homebrew OpenSSL path for macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,8 @@ else
 		# macOS-specific settings
 		CXX=clang++
 		# Use Apple's OpenCL framework
-		LDFLAGS+=-framework OpenCL
+		LDFLAGS+=-framework OpenCL -L/usr/local/opt/openssl/lib
+		CXXFLAGS+=-I/usr/local/opt/openssl/include
 		LIBS+=-lstdc++ -lcrypto
 		# Suppress unused parameter warnings that are common in cross-platform code
 		CXXFLAGS+=-Wno-unused-parameter


### PR DESCRIPTION
This commit fixes a linker error on macOS where the 'crypto' library could not be found. This was because the linker was not looking in the standard Homebrew installation path for OpenSSL.

The Makefile is updated to include the Homebrew OpenSSL include and library paths when compiling on Darwin (macOS). This should allow the project to be built on macOS without manual configuration of OpenSSL paths, assuming OpenSSL was installed with Homebrew.