### PR TITLE
fix: Use correct Homebrew OpenSSL path for Apple Silicon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,8 @@ else
 		# macOS-specific settings
 		CXX=clang++
 		# Use Apple's OpenCL framework
-		LDFLAGS+=-framework OpenCL -L/usr/local/opt/openssl/lib
-		CXXFLAGS+=-I/usr/local/opt/openssl/include
+		LDFLAGS+=-framework OpenCL -L/opt/homebrew/opt/openssl/lib
+		CXXFLAGS+=-I/opt/homebrew/opt/openssl/include
 		LIBS+=-lstdc++ -lcrypto
 		# Suppress unused parameter warnings that are common in cross-platform code
 		CXXFLAGS+=-Wno-unused-parameter


### PR DESCRIPTION
This commit fixes a linker error on Apple Silicon Macs where the 'crypto' library could not be found. This was because the linker was not looking in the correct Homebrew installation path for OpenSSL on Apple Silicon machines.

The Makefile is updated to include the `/opt/homebrew/opt/openssl` include and library paths when compiling on Darwin (macOS). This should allow the project to be built on Apple Silicon Macs without manual configuration of OpenSSL paths, assuming OpenSSL was installed with Homebrew.