### PR TITLE
fix(build): Add LDFLAGS to addrgen Makefile

### DIFF
--- a/AddrGen/Makefile
+++ b/AddrGen/Makefile
@@ -1,7 +1,7 @@
 CPPSRC:=$(wildcard *.cpp)
 
 all:
-	${CXX} -o addrgen.bin ${CPPSRC} ${INCLUDE} -I${CUDA_INCLUDE} ${CXXFLAGS} ${LIBS} -laddressutil -lsecp256k1 -lcryptoutil -lsecp256k1 -lutil -lcmdparse
+	${CXX} -o addrgen.bin ${CPPSRC} ${INCLUDE} -I${CUDA_INCLUDE} ${CXXFLAGS} ${LDFLAGS} ${LIBS} -laddressutil -lsecp256k1 -lcryptoutil -lsecp256k1 -lutil -lcmdparse
 	mkdir -p $(BINDIR)
 	cp addrgen.bin $(BINDIR)/addrgen
 


### PR DESCRIPTION
This commit fixes a linker error when building the 'addrgen' executable on macOS. The `LDFLAGS` variable, which contains the path to the OpenSSL library, was not being passed to the linker.

This resulted in a "library not found" error for the 'crypto' library. The `AddrGen/Makefile` has been updated to include `LDFLAGS` in the linker command.