### PR TITLE
fix(build): Use correct libtorch path for miniconda env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ export BUILD_CUDA
 export BUILD_MPS
 
 # Libtorch variables
-LIBTORCH_HOME=/usr/local/libtorch
+LIBTORCH_HOME=/Users/haq/miniconda3/lib/python3.12/site-packages/torch
 LIBTORCH_INCLUDE=${LIBTORCH_HOME}/include
 LIBTORCH_LIB=${LIBTORCH_HOME}/lib
 


### PR DESCRIPTION
This commit fixes a build failure on macOS when using a libtorch installation from a miniconda environment. The `LIBTORCH_HOME` path in the `Makefile` was hardcoded to `/usr/local/libtorch`, which is not correct for this setup.

The `Makefile` has been updated to point to the user-provided path for the miniconda-based libtorch installation. This should allow the project to be built successfully with the MPS backend.