### PR TITLE
fix(build): Use C++17 standard for PyTorch compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ LIBS+=-L$(LIBDIR)
 
 # C++ options
 CXX=g++
-CXXFLAGS=-O2 -std=c++11
+CXXFLAGS=-O2 -std=c++17
 LDFLAGS=
 
 # Check for OS


### PR DESCRIPTION
This commit fixes a build failure when compiling with PyTorch. The version of PyTorch being used requires a C++17 compatible compiler, but the project was being built with C++11.

The `Makefile` has been updated to use the `-std=c++17` flag, which should resolve the compilation errors related to C++17 features.