### PR TITLE
fix(build): Add MpsKeySearchDevice to include paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 CUR_DIR=$(shell pwd)
-DIRS=util AddressUtil CmdParse CryptoUtil KeyFinderLib CLKeySearchDevice CudaKeySearchDevice cudaMath clUtil cudaUtil secp256k1lib Logger embedcl
+DIRS=util AddressUtil CmdParse CryptoUtil KeyFinderLib CLKeySearchDevice CudaKeySearchDevice cudaMath clUtil cudaUtil secp256k1lib Logger embedcl MpsKeySearchDevice
 
 INCLUDE = $(foreach d, $(DIRS), -I$(CUR_DIR)/$d)
 


### PR DESCRIPTION
This commit fixes a build failure where the `MpsKeySearchDevice.h` header could not be found when compiling `main.cpp`.

The `MpsKeySearchDevice` directory was not included in the `DIRS` variable in the main `Makefile`, which meant that the compiler was not looking in the correct directory for the header file. This has been corrected.