### PR TITLE
fix(build): Correct library link order for MPS build

### DIFF
--- a/KeyFinder/Makefile
+++ b/KeyFinder/Makefile
@@ -12,7 +12,7 @@ ifeq ($(BUILD_OPENCL),1)
 	cp clKeyFinder.bin $(BINDIR)/clBitCrack
 endif
 ifeq ($(BUILD_MPS),1)
-	${CXX} -DBUILD_MPS -o mpsKeyFinder.bin ${CPPSRC} ${INCLUDE} ${CXXFLAGS} ${LDFLAGS} ${LIBS} -lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -lsecp256k1 -lMpsKeySearchDevice -llogger -lutil -lcmdparse
+	${CXX} -DBUILD_MPS -o mpsKeyFinder.bin ${CPPSRC} ${INCLUDE} ${CXXFLAGS} ${LDFLAGS} ${LIBS} -lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -lsecp256k1 -lMpsKeySearchDevice -llogger -lutil -lcmdparse -ltorch -lc10
 	mkdir -p $(BINDIR)
 	cp mpsKeyFinder.bin $(BINDIR)/mpsBitCrack
 endif


### PR DESCRIPTION
This commit fixes a linker error when building with the MPS backend on macOS. The torch libraries were not being linked in the correct order, which resulted in "undefined symbol" errors for torch functions.

The `KeyFinder/Makefile` has been updated to explicitly link the torch libraries at the end of the linker command, which resolves the issue.