### PR TITLE
fix(build): Remove duplicate torch libraries from linker command

### DIFF
--- a/KeyFinder/Makefile
+++ b/KeyFinder/Makefile
@@ -12,7 +12,7 @@ ifeq ($(BUILD_OPENCL),1)
 	cp clKeyFinder.bin $(BINDIR)/clBitCrack
 endif
 ifeq ($(BUILD_MPS),1)
-	${CXX} -DBUILD_MPS -o mpsKeyFinder.bin ${CPPSRC} ${INCLUDE} ${CXXFLAGS} ${LDFLAGS} ${LIBS} -lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -lsecp256k1 -lMpsKeySearchDevice -llogger -lutil -lcmdparse -ltorch -lc10
+	${CXX} -DBUILD_MPS -o mpsKeyFinder.bin ${CPPSRC} ${INCLUDE} ${CXXFLAGS} ${LDFLAGS} ${LIBS} -lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -lsecp256k1 -lMpsKeySearchDevice -llogger -lutil -lcmdparse
 	mkdir -p $(BINDIR)
 	cp mpsKeyFinder.bin $(BINDIR)/mpsBitCrack
 endif


### PR DESCRIPTION
This commit fixes a linker error when building with the MPS backend on macOS. The torch libraries were being included twice in the linker command, which caused the linker to fail with "undefined symbol" errors.

The `KeyFinder/Makefile` has been updated to remove the duplicate `-ltorch` and `-lc10` flags. The `LIBS` variable, which is passed from the main `Makefile`, already contains these flags, so they are not needed here.