### PR TITLE
fix(build): Remove duplicate torch libraries from KeyFinder Makefile

### DIFF
--- a/KeyFinder/Makefile
+++ b/KeyFinder/Makefile
@@ -12,7 +12,7 @@ ifeq ($(BUILD_OPENCL),1)
 	cp clKeyFinder.bin $(BINDIR)/clBitCrack
 endif
 ifeq ($(BUILD_MPS),1)
-	${CXX} -DBUILD_MPS -o mpsKeyFinder.bin ${CPPSRC} ${INCLUDE} ${CXXFLAGS} ${LDFLAGS} ${LIBS} -lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -lsecp256k1 -lMpsKeySearchDevice -llogger -lutil -lcmdparse -ltorch -lc10
+	${CXX} -DBUILD_MPS -o mpsKeyFinder.bin ${CPPSRC} ${INCLUDE} ${CXXFLAGS} ${LDFLAGS} ${LIBS} -lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -lsecp256k1 -lMpsKeySearchDevice -llogger -lutil -lcmdparse
 	mkdir -p $(BINDIR)
 	cp mpsKeyFinder.bin $(BINDIR)/mpsBitCrack
 endif


### PR DESCRIPTION
This commit removes the explicit linking of torch libraries from the `KeyFinder/Makefile`. These libraries are already included in the `LIBS` variable from the main `Makefile`, and the duplication was causing linker errors on macOS.

This change should resolve the "undefined symbol" errors for torch functions by ensuring that the libraries are linked only once and in the correct order.