### PR TITLE
refactor(build): Isolate torch linking to KeyFinder Makefile

### DIFF
--- a/KeyFinder/Makefile
+++ b/KeyFinder/Makefile
@@ -12,7 +12,7 @@ ifeq ($(BUILD_OPENCL),1)
 	cp clKeyFinder.bin $(BINDIR)/clBitCrack
 endif
 ifeq ($(BUILD_MPS),1)
-	${CXX} -DBUILD_MPS -o mpsKeyFinder.bin ${CPPSRC} ${INCLUDE} ${CXXFLAGS} ${LDFLAGS} ${LIBS} -lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -lsecp256k1 -lMpsKeySearchDevice -llogger -lutil -lcmdparse
+	${CXX} -DBUILD_MPS -o mpsKeyFinder.bin ${CPPSRC} ${INCLUDE} ${CXXFLAGS} ${LDFLAGS} ${LIBS} -L${LIBTORCH_LIB} -lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -lsecp256k1 -lMpsKeySearchDevice -llogger -lutil -lcmdparse -ltorch -lc10
 	mkdir -p $(BINDIR)
 	cp mpsKeyFinder.bin $(BINDIR)/mpsBitCrack
 endif

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,6 @@ endif
 ifeq ($(BUILD_MPS),1)
 	TARGETS:=${TARGETS} dir_mpsKeySearchDevice
 	CXXFLAGS:=${CXXFLAGS} -I${LIBTORCH_INCLUDE} -I${LIBTORCH_INCLUDE}/torch/csrc/api/include
-	LIBS:=${LIBS} -L${LIBTORCH_LIB} -ltorch -lc10
 endif
 
 


### PR DESCRIPTION
This commit refactors the build process for the MPS backend to further isolate the torch library linking and hopefully resolve the persistent linker errors on macOS.

The torch-related `LIBS` modifications have been removed from the main `Makefile`, and the library path and libraries are now added directly to the `KeyFinder/Makefile`. This makes the `mpsKeyFinder` build command self-contained and should prevent any issues with linker flag ordering.