### PR TITLE
fix(build): Add rpath for torch libraries on macOS

### DIFF
--- a/Makefile.mps
+++ b/Makefile.mps
@@ -25,7 +25,7 @@ INCLUDE += -I${LIBTORCH_INCLUDE} -I${LIBTORCH_INCLUDE}/torch/csrc/api/include
 CXXFLAGS=-O2 -std=c++17 -Wno-unused-parameter
 
 # Linker flags
-LDFLAGS=-L/opt/homebrew/opt/openssl/lib -L${LIBDIR} -L${LIBTORCH_LIB}
+LDFLAGS=-L/opt/homebrew/opt/openssl/lib -L${LIBDIR} -L${LIBTORCH_LIB} -rpath ${LIBTORCH_LIB}
 
 # Libraries
 LIBS=-lkeyfinder -laddressutil -lsecp256k1 -lcryptoutil -lMpsKeySearchDevice -llogger -lutil -lcmdparse -ltorch -lc10 -lcrypto


### PR DESCRIPTION
This commit fixes a runtime error on macOS where the `mpsBitCrack` executable could not find the `libtorch.dylib` library.

The `Makefile.mps` has been updated to include the `-rpath` linker flag, which embeds the path to the torch libraries in the executable. This allows the dynamic linker to find the required libraries at runtime.