### PR TITLE
fix(build): Define BUILD_MPS when compiling with Makefile.mps

### DIFF
--- a/Makefile.mps
+++ b/Makefile.mps
@@ -22,7 +22,7 @@ LIBTORCH_LIB=${LIBTORCH_HOME}/lib
 INCLUDE += -I${LIBTORCH_INCLUDE} -I${LIBTORCH_INCLUDE}/torch/csrc/api/include
 
 # C++ flags
-CXXFLAGS=-O2 -std=c++17 -Wno-unused-parameter
+CXXFLAGS=-O2 -std=c++17 -Wno-unused-parameter -DBUILD_MPS
 
 # Linker flags
 LDFLAGS=-L/opt/homebrew/opt/openssl/lib -L${LIBDIR} -L${LIBTORCH_LIB} -rpath ${LIBTORCH_LIB}


### PR DESCRIPTION
This commit fixes an issue where the `BUILD_MPS` preprocessor flag was not being defined when compiling the `mpsBitCrack` executable using `Makefile.mps`. This caused all the MPS-related code to be excluded from the build, resulting in no MPS device being detected at runtime.

The `CXXFLAGS` in `Makefile.mps` has been updated to include the `-DBUILD_MPS` flag.